### PR TITLE
238. Product of Array Except Self

### DIFF
--- a/src/solutions.rs
+++ b/src/solutions.rs
@@ -6,6 +6,7 @@ mod s_198_house_robbers;
 mod s_19_remove_nth_node_from_end_of_list;
 mod s_206_reverse_linked_list;
 mod s_22_generate_parentheses;
+mod s_238_product_of_array_except_self;
 mod s_3_longest_substring_without_repeating_characters;
 mod s_417_pacific_atlantic_water_flow;
 mod s_424_longest_repeating_character_replacement;

--- a/src/solutions/s_238_product_of_array_except_self.rs
+++ b/src/solutions/s_238_product_of_array_except_self.rs
@@ -1,0 +1,40 @@
+struct Solution {}
+
+impl Solution {
+    pub fn product_except_self(nums: Vec<i32>) -> Vec<i32> {
+        let mut forward_products = vec![1; nums.len()];
+        let mut backward_products = vec![1; nums.len()];
+        for i in 1..nums.len() {
+            forward_products[i] = forward_products[i - 1] * nums[i - 1];
+            let offset = nums.len() - 1 - i;
+            backward_products[offset] = backward_products[offset + 1] * nums[offset + 1];
+        }
+
+        let mut res = vec![];
+        for i in 0..forward_products.len() {
+            res.push(forward_products[i] * backward_products[i])
+        }
+        return res;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_only_positive_integer() {
+        let input = vec![1, 2, 3, 4];
+        let expected = vec![24, 12, 8, 6];
+        let res = Solution::product_except_self(input);
+        assert_eq!(res, expected);
+    }
+
+    #[test]
+    fn test_zero_and_negative() {
+        let input = vec![-1, 1, 0, -3, 3];
+        let expected = vec![0, 0, 9, 0, 0];
+        let res = Solution::product_except_self(input);
+        assert_eq!(res, expected);
+    }
+}


### PR DESCRIPTION
## Problem Link

https://leetcode.com/problems/product-of-array-except-self/description/

## Solution

One immediate approach is to calculate the product of all elements in `nums`, and then divide this product by each element at index `i` to obtain the result.
For example, if `nums` is `[2,3,4]`, the total product is `2 * 3 * 4 = 24`. Dividing this product by each element gives `[24/2, 24/3, 24/4] = [12, 8, 6]`.
This solution operates in O(n) time complexity, but division is not allowed in this problem.

Therefore, another approach can be considered.
In this approach, for each index `i` in `nums`, we calculate the product of all elements before `i` (from 0 to `i-1`) and the product of all elements after `i` (from `i+1` to the end).
Finally,  we multiply these two products together to get the desired result, which is the product of all elements expect for `nums[i]`.