### PR TITLE
128. Longest Consecutive Sequence

### DIFF
--- a/src/solutions.rs
+++ b/src/solutions.rs
@@ -1,4 +1,5 @@
 mod s_110_balanced_binary_tree;
+mod s_128_longest_consecutive_sequence;
 mod s_143_reorder_list;
 mod s_153_find_minimum_in_rotated_sorted_array;
 mod s_155_min_stack;

--- a/src/solutions/s_128_longest_consecutive_sequence.rs
+++ b/src/solutions/s_128_longest_consecutive_sequence.rs
@@ -1,0 +1,44 @@
+use std::collections::HashSet;
+
+struct Solution {}
+
+impl Solution {
+    pub fn longest_consecutive(nums: Vec<i32>) -> i32 {
+        let mut num_set = HashSet::<i32>::new();
+        for num in nums.iter() {
+            num_set.insert(*num);
+        }
+
+        let mut res = 0;
+
+        for i in 0..nums.len() {
+            if Self::is_first_in_sequence(&num_set, nums[i]) {
+                let mut cnt = 0;
+                let mut num = nums[i];
+                while num_set.contains(&num) {
+                    cnt += 1;
+                    num += 1
+                }
+                res = res.max(cnt);
+            }
+        }
+
+        return res;
+    }
+
+    fn is_first_in_sequence(num_set: &HashSet<i32>, num: i32) -> bool {
+        return !num_set.contains(&(num - 1));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let nums = vec![100, 4, 200, 1, 3, 2];
+        let res = Solution::longest_consecutive(nums);
+        assert_eq!(res, 4)
+    }
+}


### PR DESCRIPTION
## Problem Link

https://leetcode.com/problems/longest-consecutive-sequence/description/

## Solution

A solution that springs to mind is to sort the input `nums` in ascending order and traverse the sorted array.
During the traversal, if the adjacent elements are consecutive, increment a counter.
If the current element is not consecutive to the previous element, reset the counter to 0 and start again.
This approach operations in `O(n * log n )` time complexity, but we're supposed to solve this problem in `O(n)`.

For a more efficient approach, consider traversing the unsorted `nums` directly.
In each iteration, if the current element is the start of a sequence, determine how many consecutive elements are contained in `nums` staring from that element.
An element is considered the start of a sequence if the value `element -1` is not present in `nume`.
To do this with a time complexity of `O(n)`, use a hash set to store all elements of `nums`